### PR TITLE
Added wide-dhcpv6 to seed-jobs

### DIFF
--- a/jenkins-scripts/jobs.json
+++ b/jenkins-scripts/jobs.json
@@ -446,5 +446,12 @@
   "gitUrl": "https://github.com/dd010101/vyos-build.git",
   "branchRegex": "(equuleus|sagitta|current)",
   "jenkinsfilePath": "packages/vyos-build-container/Jenkinsfile"
+ },
+ {
+  "name": "wide-dhcpv6",
+  "description": "shared",
+  "gitUrl": "https://github.com/vyos/vyos-build.git",
+  "branchRegex": "(equuleus|sagitta)",
+  "jenkinsfilePath": "packages/wide-dhcpv6/Jenkinsfile"
  }
 ]


### PR DESCRIPTION
wide-dhcpv6 was missing from jobs.json. build-vyos-image was still able to build an iso from Debian sources, but without the necessary Vyos patches certain dhcpv6-pd configs would fail.