### PR TITLE
Move branch filter logic

### DIFF
--- a/auto/helper-logic
+++ b/auto/helper-logic
@@ -423,6 +423,11 @@ function BuildJobs {
 
     for BRANCH in $BRANCHES
     do
+      # Branch filter
+      if ! echo $BRANCH | grep -E "$SELECTED_BRANCH_REGEX" > /dev/null; then
+        continue
+      fi
+
       JOBS+=( "$JOB_NAME|$BRANCH" )
     done
   done < <(cat $1 | jq -c '.[]')
@@ -483,12 +488,6 @@ function BuildJobs {
       jobSplit=(${job//|/ })
       JOB_NAME="${jobSplit[0]}"
       JOB_BRANCH="${jobSplit[1]}"
-
-      # Branch filter
-      if ! echo $JOB_BRANCH | grep -E "$SELECTED_BRANCH_REGEX" > /dev/null; then
-        PrintJobExcluded $JOB_NAME $JOB_BRANCH
-        continue
-      fi
 
       # Download job data and parse it.
       URL="${JENKINS_URL}/job/${JOB_NAME}/job/${JOB_BRANCH}/lastBuild/api/json"
@@ -564,12 +563,6 @@ function BuildJobs {
         jobSplit=(${job//|/ })
         JOB_NAME="${jobSplit[0]}"
         JOB_BRANCH="${jobSplit[1]}"
-
-        # Branch filter
-        if ! echo $JOB_BRANCH | grep -E "$SELECTED_BRANCH_REGEX" > /dev/null; then
-          PrintJobExcluded $JOB_NAME $JOB_BRANCH
-          continue
-        fi
 
         # Download job data and parse it.
         URL="${JENKINS_URL}/job/${JOB_NAME}/job/${JOB_BRANCH}/lastBuild/api/json"


### PR DESCRIPTION
By moving it up here, we make sure only jobs that should be built is added to the JOBS array in the first place. This is a better way, since the skipped jobs won't occupy the build slots (since we take X number of jobs from the JOBS array for each batch, for a CONCURRENT_JOBS_COUNT of 10 - if 6 is skipped, only 4 jobs will be started).

Now, they are not added to the JOBS array, so the rest works as intended.

Before:
```
Building jobs in Jenkins...
Total number of jobs: 91
Concurrent jobs: 10 (Can be overridden by setting the CONCURRENT_JOBS_COUNT environment variable)

[   Running   ] Package: aws-gateway-load-balancer-tunnel-handler - Branch: sagitta
[   Running   ] Package: ddclient - Branch: sagitta
[   Skipped   ] Package: dropbear - Branch: equuleus (excluded)
[   Running   ] Package: dropbear - Branch: sagitta
[   Running   ] Package: ethtool - Branch: sagitta
[   Skipped   ] Package: frr - Branch: equuleus (excluded)
[   Running   ] Package: frr - Branch: sagitta
[   Skipped   ] Package: hostap - Branch: equuleus (excluded)
[   Running   ] Package: hostap - Branch: sagitta
[   Running   ] Package: hsflowd - Branch: sagitta
```

After:
```
Building jobs in Jenkins...
Total number of jobs: 91
Concurrent jobs: 10 (Can be overridden by setting the CONCURRENT_JOBS_COUNT environment variable)

[   Running   ] Package: aws-gateway-load-balancer-tunnel-handler - Branch: sagitta
[   Running   ] Package: ddclient - Branch: sagitta
[   Running   ] Package: dropbear - Branch: sagitta
[   Running   ] Package: ethtool - Branch: sagitta
[   Running   ] Package: frr - Branch: sagitta
[   Running   ] Package: hostap - Branch: sagitta
[   Running   ] Package: hsflowd - Branch: sagitta
[   Running   ] Package: hvinfo - Branch: sagitta
[   Running   ] Package: ipaddrcheck - Branch: sagitta
[   Running   ] Package: isc-dhcp - Branch: sagitta
```