### PR TITLE
Restart uncron to fix initial socket ownership

### DIFF
--- a/4-uncron.sh
+++ b/4-uncron.sh
@@ -73,6 +73,9 @@ systemctl daemon-reload > /dev/null 2>&1
 # Ensure uncron service is enabled.
 systemctl enable --now uncron.service > /dev/null 2>&1
 
+# restart uncron service to fix user/group issue
+systemctl restart uncron.service > /dev/null 2>&1
+
 echo
 echo "Part 4 of the installer is now done."
 echo "Please run part five (5-docker-jobs.sh) to set up the vyos build container jobs."


### PR DESCRIPTION
The uncron binary creates /run/uncron/uncron.sock while still running as root, before switching to the jenkins user.
As a result, even with User=jenkins set in the systemd service file, the socket initially appears owned by root:root.

This commit adds a restart of uncron.service during installation to recreate the socket with correct ownership (jenkins:jenkins), avoiding permission issues for Jenkins jobs.